### PR TITLE
Bump version to 2.0.4 in manifest.json

### DIFF
--- a/custom_components/azure_ai_tasks/manifest.json
+++ b/custom_components/azure_ai_tasks/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/loryanstrant/HA-Azure-AI-tasks/issues",
   "requirements": ["aiohttp>=3.8.0", "packaging>=21.0"],
-  "version": "2.0.3"
+  "version": "2.0.4"
 }


### PR DESCRIPTION
This pull request makes a minor update to the `manifest.json` file, incrementing the version number of the `azure_ai_tasks` custom component from 2.0.3 to 2.0.4.